### PR TITLE
Add support for running server in Gin release mode

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -4,26 +4,38 @@ import (
 	"job-parser-backend/internal/handler"
 	"log"
 	"os"
-
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 )
 
+func RegisterHandlers(r *gin.Engine){
+	handler.RegisterJobHandler(r)
+}
+
 func main() {
-	err := godotenv.Load() 
-	if err != nil {
+	if err := godotenv.Load(); err != nil {
 		log.Fatal("Error loading .env file")
 	}
+
+	mode := os.Getenv("MODE")
+	if(mode == "release") {
+		gin.SetMode(gin.ReleaseMode)
+	}
+
+	log.Println("Running in", gin.Mode(), "mode")
+
 	router:= gin.Default()
-	handler.RegisterJobHandler(router)
+
+	RegisterHandlers(router)
 
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8000"
 	}
 
-	err = router.Run("0.0.0.0:" + port)
-	if err != nil {
+	log.Println("Server starting on port", port)
+
+	if err := router.Run(":" + port); err != nil {
 		log.Fatal("Failed to start server: ", err)
 	}
 }

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"job-parser-backend/internal/handler"
 	"log"
+	"os"
+
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 )
@@ -14,5 +16,14 @@ func main() {
 	}
 	router:= gin.Default()
 	handler.RegisterJobHandler(router)
-	router.Run("localhost:8000")
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8000"
+	}
+
+	err = router.Run("0.0.0.0:" + port)
+	if err != nil {
+		log.Fatal("Failed to start server: ", err)
+	}
 }


### PR DESCRIPTION
This PR introduces support for running the server in Gin’s release mode by reading a MODE environment variable.

Fixes: #3 