### PR TITLE
feat: Implement edit job feature

### DIFF
--- a/backend/internal/client/groq_client.go
+++ b/backend/internal/client/groq_client.go
@@ -22,27 +22,27 @@ type GroqClient interface {
 	POST(url string, body map[string]any) (*model.GroqResponse, error)
 }
 
-func CreateGroqClient(httpClient *http.Client ) (GroqClient, error) {
+func CreateGroqClient(httpClient *http.Client) (GroqClient, error) {
 	groqAPIKey := os.Getenv("GROQ_API_KEY")
-	
+
 	if groqAPIKey == "" {
 		return nil, fmt.Errorf("Groq API key not set")
 	}
-	
-	return  &groqClient{
+
+	return &groqClient{
 		apiKey:     groqAPIKey,
 		baseURL:    "https://api.groq.com/openai/v1/chat/completions",
 		httpClient: httpClient,
 	}, nil
 }
 
-func(c *groqClient) POST(url string, body map[string]any) (*model.GroqResponse, error) {
+func (c *groqClient) POST(url string, body map[string]any) (*model.GroqResponse, error) {
 	var response model.GroqResponse
 
 	if err := c.request("POST", "", body, &response); err != nil {
 		return nil, fmt.Errorf("error making Groq request: %w", err)
 	}
-	
+
 	if len(response.Choices) == 0 || response.Choices[0].Message.Content == "" {
 		return nil, errors.New("empty or invalid response from Groq API: no choices or content found")
 	}
@@ -50,7 +50,7 @@ func(c *groqClient) POST(url string, body map[string]any) (*model.GroqResponse, 
 	return &response, nil
 }
 
-func(c *groqClient) request(requestType string, url string, body map[string]any, responseFormat any) error {
+func (c *groqClient) request(requestType string, url string, body map[string]any, responseFormat any) error {
 	url = c.baseURL + url
 
 	bodyBytes, err := json.Marshal(body)

--- a/backend/internal/client/notion_client.go
+++ b/backend/internal/client/notion_client.go
@@ -26,9 +26,9 @@ type NotionClient interface {
 	CreateNotionPage(databaseID string, body map[string]any) (*model.NotionPage, error)
 }
 
-func CreateNotionClient(httpClient *http.Client ) (NotionClient, error) {
+func CreateNotionClient(httpClient *http.Client) (NotionClient, error) {
 	notionApiKey := os.Getenv("NOTION_API_KEY")
-	
+
 	if notionApiKey == "" {
 		return nil, errors.New("Notion API key is not set")
 	}
@@ -41,8 +41,8 @@ func CreateNotionClient(httpClient *http.Client ) (NotionClient, error) {
 	}, nil
 }
 
-func(c *notionClient) request(requestType string, url string, body map[string]any, responseFormat any) error {
-	
+func (c *notionClient) request(requestType string, url string, body map[string]any, responseFormat any) error {
+
 	url = c.baseURL + url
 
 	bodyBytes, err := json.Marshal(body)

--- a/backend/internal/handler/job_handler.go
+++ b/backend/internal/handler/job_handler.go
@@ -16,7 +16,7 @@ type JobHandler interface {
 	getStatsHandler(context *gin.Context)
 	getStreakHandler(context *gin.Context)
 	registerJobHandler(router *gin.Engine)
-}	
+}
 
 type jobHandler struct {
 	service service.JobService
@@ -28,7 +28,7 @@ func CreateJobHandler(svc service.JobService, router *gin.Engine) JobHandler {
 	return jobHandler
 }
 
-func(h *jobHandler) registerJobHandler(router *gin.Engine) {
+func (h *jobHandler) registerJobHandler(router *gin.Engine) {
 	router.GET("/api/job/recent", h.getRecentlySavedJobsHandler)
 	router.GET("/api/job/stats", h.getStatsHandler)
 	router.GET("/api/job/streak", h.getStreakHandler)
@@ -39,7 +39,7 @@ func(h *jobHandler) registerJobHandler(router *gin.Engine) {
 	router.PUT("/api/job/:pageID", h.updateJobHandler)
 }
 
-func(h *jobHandler) saveJobHandler(context *gin.Context) {
+func (h *jobHandler) saveJobHandler(context *gin.Context) {
 	var req model.Job
 	if err := context.BindJSON(&req); err != nil {
 		logError(err)
@@ -56,7 +56,7 @@ func(h *jobHandler) saveJobHandler(context *gin.Context) {
 	context.JSON(http.StatusOK, res)
 }
 
-func(h *jobHandler) compareJobPostingHandler(context *gin.Context) {
+func (h *jobHandler) compareJobPostingHandler(context *gin.Context) {
 	type CompareJobPostingRequest struct {
 		Resume     any    `json:"resume"`
 		JobPosting string `json:"jobPosting"`
@@ -77,8 +77,9 @@ func(h *jobHandler) compareJobPostingHandler(context *gin.Context) {
 	context.JSON(http.StatusOK, res)
 }
 
-func(h *jobHandler) getRecentlySavedJobsHandler(context *gin.Context) {
-	jobs, err := h.service.GetRecentlySavedJobs()
+func (h *jobHandler) getRecentlySavedJobsHandler(context *gin.Context) {
+	status := context.Query("status")
+	jobs, err := h.service.GetRecentlySavedJobs(status)
 	if err != nil {
 		logError(err)
 		context.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch saved jobs"})
@@ -87,16 +88,21 @@ func(h *jobHandler) getRecentlySavedJobsHandler(context *gin.Context) {
 	context.JSON(http.StatusOK, jobs)
 }
 
-
-func(h *jobHandler) updateJobHandler(context *gin.Context) {
+func (h *jobHandler) updateJobHandler(context *gin.Context) {
 	pageID := context.Param("pageID")
+	var req model.Job
 
 	if pageID == "" {
 		context.JSON(http.StatusBadRequest, gin.H{"error": "Missing pageID in path"})
 		return
 	}
+	if err := context.BindJSON(&req); err != nil {
+		logError(err)
+		context.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
 
-	err := h.service.UpdateJob(pageID)
+	err := h.service.UpdateJob(pageID, req)
 	if err != nil {
 		logError(err)
 		context.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update job"})
@@ -105,7 +111,7 @@ func(h *jobHandler) updateJobHandler(context *gin.Context) {
 	context.JSON(http.StatusOK, gin.H{})
 }
 
-func(h *jobHandler) getStatsHandler(context *gin.Context) {
+func (h *jobHandler) getStatsHandler(context *gin.Context) {
 	rangeParam := context.Query("range")
 
 	statResult, err := h.service.GetStats(rangeParam)
@@ -117,7 +123,7 @@ func(h *jobHandler) getStatsHandler(context *gin.Context) {
 	context.JSON(http.StatusOK, statResult)
 }
 
-func(h *jobHandler) getStreakHandler(context *gin.Context) {
+func (h *jobHandler) getStreakHandler(context *gin.Context) {
 	streakStat, err := h.service.GetStreak()
 	if err != nil {
 		logError(err)

--- a/backend/internal/model/groq.go
+++ b/backend/internal/model/groq.go
@@ -12,3 +12,8 @@ type GroqChoice struct {
 type GroqMessage struct {
 	Content string `json:"content"`
 }
+
+const (
+	Mixtral_Saba_24b   string = "mistral-saba-24b"
+	Gemma2_9B_Instruct string = "gemma2-9b-it"
+)

--- a/backend/internal/model/job.go
+++ b/backend/internal/model/job.go
@@ -4,6 +4,7 @@ package model
 type Job struct {
 	ID          string `json:"id"`
 	Country     string `json:"country"`
+	Status      string `json:"status"`
 	Company     string `json:"company"`
 	URL         string `json:"url"`
 	Title       string `json:"title"`

--- a/dist/css/index.css
+++ b/dist/css/index.css
@@ -15,11 +15,11 @@
     --color-red-800: oklch(44.4% 0.177 26.899);
     --color-yellow-100: oklch(97.3% 0.071 103.193);
     --color-yellow-300: oklch(90.5% 0.182 98.111);
+    --color-yellow-500: oklch(79.5% 0.184 86.047);
+    --color-yellow-600: oklch(68.1% 0.162 75.834);
     --color-yellow-800: oklch(47.6% 0.114 61.907);
     --color-green-100: oklch(96.2% 0.044 156.743);
     --color-green-300: oklch(87.1% 0.15 154.449);
-    --color-green-500: oklch(72.3% 0.219 149.579);
-    --color-green-600: oklch(62.7% 0.194 149.214);
     --color-green-800: oklch(44.8% 0.119 151.328);
     --color-teal-500: oklch(70.4% 0.14 182.503);
     --color-blue-500: oklch(62.3% 0.214 259.815);
@@ -299,9 +299,6 @@
   .inset-0 {
     inset: calc(var(--spacing) * 0);
   }
-  .top-1 {
-    top: calc(var(--spacing) * 1);
-  }
   .top-1\/2 {
     top: calc(1 / 2 * 100%);
   }
@@ -335,6 +332,9 @@
       max-width: 96rem;
     }
   }
+  .m-4 {
+    margin: calc(var(--spacing) * 4);
+  }
   .mx-auto {
     margin-inline: auto;
   }
@@ -347,11 +347,8 @@
   .mt-4 {
     margin-top: calc(var(--spacing) * 4);
   }
-  .mr-1 {
-    margin-right: calc(var(--spacing) * 1);
-  }
-  .mb-1 {
-    margin-bottom: calc(var(--spacing) * 1);
+  .mr-2 {
+    margin-right: calc(var(--spacing) * 2);
   }
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
@@ -398,29 +395,8 @@
   .h-full {
     height: 100%;
   }
-  .max-h-1 {
-    max-height: calc(var(--spacing) * 1);
-  }
-  .max-h-1\/2 {
-    max-height: calc(1 / 2 * 100%);
-  }
   .max-h-4\/5 {
     max-height: calc(4 / 5 * 100%);
-  }
-  .max-h-96 {
-    max-height: calc(var(--spacing) * 96);
-  }
-  .max-h-fit {
-    max-height: fit-content;
-  }
-  .max-h-full {
-    max-height: 100%;
-  }
-  .max-h-screen {
-    max-height: 100vh;
-  }
-  .w-1 {
-    width: calc(var(--spacing) * 1);
   }
   .w-1\/2 {
     width: calc(1 / 2 * 100%);
@@ -437,9 +413,6 @@
   .w-10 {
     width: calc(var(--spacing) * 10);
   }
-  .w-11 {
-    width: calc(var(--spacing) * 11);
-  }
   .w-11\/12 {
     width: calc(11 / 12 * 100%);
   }
@@ -452,18 +425,8 @@
   .max-w-sm {
     max-width: var(--container-sm);
   }
-  .flex-shrink {
-    flex-shrink: 1;
-  }
   .shrink-0 {
     flex-shrink: 0;
-  }
-  .border-collapse {
-    border-collapse: collapse;
-  }
-  .-translate-y-1 {
-    --tw-translate-y: calc(var(--spacing) * -1);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-y-1\/2 {
     --tw-translate-y: calc(calc(1 / 2 * 100%) * -1);
@@ -519,6 +482,13 @@
       margin-inline-end: calc(calc(var(--spacing) * 2) * calc(1 - var(--tw-space-x-reverse)));
     }
   }
+  .space-x-4 {
+    :where(& > :not(:last-child)) {
+      --tw-space-x-reverse: 0;
+      margin-inline-start: calc(calc(var(--spacing) * 4) * var(--tw-space-x-reverse));
+      margin-inline-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-x-reverse)));
+    }
+  }
   .divide-y {
     :where(& > :not(:last-child)) {
       --tw-divide-y-reverse: 0;
@@ -570,10 +540,6 @@
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 2px;
   }
-  .border-solid {
-    --tw-border-style: solid;
-    border-style: solid;
-  }
   .border-blue-500 {
     border-color: var(--color-blue-500);
   }
@@ -582,9 +548,6 @@
   }
   .border-green-300 {
     border-color: var(--color-green-300);
-  }
-  .border-green-500 {
-    border-color: var(--color-green-500);
   }
   .border-red-300 {
     border-color: var(--color-red-300);
@@ -595,17 +558,14 @@
   .border-yellow-300 {
     border-color: var(--color-yellow-300);
   }
+  .border-yellow-500 {
+    border-color: var(--color-yellow-500);
+  }
   .border-b-black {
     border-bottom-color: var(--color-black);
   }
-  .bg-black {
-    background-color: var(--color-black);
-  }
-  .bg-black\/70 {
-    background-color: color-mix(in srgb, #000 70%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-black) 70%, transparent);
-    }
+  .bg-gray-300 {
+    background-color: var(--color-gray-300);
   }
   .bg-gray-800 {
     background-color: var(--color-gray-800);
@@ -621,9 +581,6 @@
   }
   .bg-slate-800 {
     background-color: var(--color-slate-800);
-  }
-  .bg-transparent {
-    background-color: transparent;
   }
   .bg-white {
     background-color: var(--color-white);
@@ -746,9 +703,6 @@
   .text-gray-700 {
     color: var(--color-gray-700);
   }
-  .text-green-500 {
-    color: var(--color-green-500);
-  }
   .text-green-800 {
     color: var(--color-green-800);
   }
@@ -760,6 +714,9 @@
   }
   .text-white {
     color: var(--color-white);
+  }
+  .text-yellow-500 {
+    color: var(--color-yellow-500);
   }
   .text-yellow-800 {
     color: var(--color-yellow-800);
@@ -880,10 +837,6 @@
     --tw-ease: var(--ease-out);
     transition-timing-function: var(--ease-out);
   }
-  .outline-none {
-    --tw-outline-style: none;
-    outline-style: none;
-  }
   .group-hover\:ml-2 {
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
@@ -922,17 +875,17 @@
       }
     }
   }
+  .hover\:bg-gray-400 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-400);
+      }
+    }
+  }
   .hover\:bg-gray-800 {
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-gray-800);
-      }
-    }
-  }
-  .hover\:bg-green-600 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-green-600);
       }
     }
   }
@@ -950,16 +903,18 @@
       }
     }
   }
+  .hover\:bg-yellow-600 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-yellow-600);
+      }
+    }
+  }
   .hover\:text-white {
     &:hover {
       @media (hover: hover) {
         color: var(--color-white);
       }
-    }
-  }
-  .focus\:border-blue-500 {
-    &:focus {
-      border-color: var(--color-blue-500);
     }
   }
   .focus\:border-transparent {
@@ -976,20 +931,6 @@
         var(--tw-ring-shadow), var(--tw-shadow);
     }
   }
-  .focus\:ring-2 {
-    &:focus {
-      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width))
-        var(--tw-ring-color, currentcolor);
-      box-shadow:
-        var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow),
-        var(--tw-ring-shadow), var(--tw-shadow);
-    }
-  }
-  .focus\:ring-blue-500 {
-    &:focus {
-      --tw-ring-color: var(--color-blue-500);
-    }
-  }
   .focus\:ring-slate-500 {
     &:focus {
       --tw-ring-color: var(--color-slate-500);
@@ -1001,16 +942,6 @@
       outline-style: none;
     }
   }
-  .active\:bg-blue-600 {
-    &:active {
-      background-color: var(--color-blue-600);
-    }
-  }
-  .active\:bg-green-600 {
-    &:active {
-      background-color: var(--color-green-600);
-    }
-  }
   .md\:max-w-md {
     @media (width >= 48rem) {
       max-width: var(--container-md);
@@ -1018,7 +949,7 @@
   }
 }
 body {
-  width: 600px;
+  width: 540px;
   height: 500px;
   overflow: hidden;
 }

--- a/dist/index.html
+++ b/dist/index.html
@@ -189,6 +189,20 @@
             />
           </div>
 
+          <div class="flex space-x-4 m-4">
+            <button
+              id="get-all-jobs"
+              class="cursor-pointer job-filter px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-400 transition"
+            >
+              All
+            </button>
+            <button
+              id="get-not-applied-jobs"
+              class="cursor-pointer job-filter px-4 py-2 bg-gray-300 text-white rounded-lg hover:bg-gray-400 transition"
+            >
+              Not Applied
+            </button>
+          </div>
           <div class="w-full overflow-x-auto">
             <table class="w-full divide-y divide-slate-200">
               <thead class="bg-slate-100 text-slate-800">
@@ -211,7 +225,7 @@
           <div class="w-full flex items-center justify-center">
             <select
               id="stat-dropdown"
-              class="appearance-none py-2 px-3 rounded-md border border-gray-300 bg-white text-gray-700 shadow-xs focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              class="appearance-none py-2 px-3 rounded-md border border-gray-300 bg-white text-gray-700 shadow-xs cursor-pointer focus:outline-none focus:ring-1 focus:ring-slate-500 focus:border-transparent transition"
             ></select>
           </div>
           <div class="flex flex-col items-center mb-4">
@@ -237,6 +251,7 @@
       </div>
     </div>
 
+    <!-- Modal -->
     <div
       class="main-modal fixed w-full h-full inset-0 z-50 overflow-hidden flex justify-center items-center animated fadeIn faster overflow-y-auto"
       style="background: rgba(0, 0, 0, 0.7)"
@@ -274,6 +289,11 @@
               class="cursor-pointer hidden text-center settings-save-button w-full focus:outline-none px-4 bg-slate-800 p-3 ml-3 rounded-lg text-white hover:bg-slate-700"
             >
               Save
+            </button>
+            <button
+              class="cursor-pointer hidden text-center edit-job-button w-full focus:outline-none px-4 bg-slate-800 p-3 ml-3 rounded-lg text-white hover:bg-slate-700"
+            >
+              Edit
             </button>
           </div>
         </div>

--- a/dist/scripts/background/api.js
+++ b/dist/scripts/background/api.js
@@ -35,8 +35,8 @@ export const compareJobPosting = async ({ resume, jobPosting }) => {
 }
 
 // Get list of recently saved jobs
-export const getRecentlySavedJobs = async () => {
-  const response = await fetchWrapper(`recent`)
+export const getRecentlySavedJobs = async (status) => {
+  const response = await fetchWrapper(`recent?status=${status}`)
 
   if (!response.ok) throw new Error('Failed to get saved jobs')
   return await response.json()
@@ -59,9 +59,11 @@ export const getStreak = async () => {
 }
 
 // Mark job as applied
-export const updateJob = async (pageId) => {
+export const updateJob = async (pageId, job) => {
   const response = await fetchWrapper(`${pageId}`, {
     method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(job),
   })
 
   if (!response.ok) throw new Error('Failed to update job')

--- a/dist/scripts/background/background.js
+++ b/dist/scripts/background/background.js
@@ -28,7 +28,7 @@ chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
       })
     return true
   } else if (request.action === REQUESTACTION.GETSAVEDJOBS) {
-    getRecentlySavedJobs()
+    getRecentlySavedJobs(request.status)
       .then((data) => {
         sendResponse({
           message: SUCCESSMESSAGE,
@@ -79,7 +79,7 @@ chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
 
     return true
   } else if (request.action === REQUESTACTION.UPDATEJOB) {
-    updateJob(request.pageId)
+    updateJob(request.pageId, request.job)
       .then(() => {
         sendResponse({
           message: SUCCESSMESSAGE,

--- a/dist/scripts/utils/constants.js
+++ b/dist/scripts/utils/constants.js
@@ -19,3 +19,12 @@ export const RANGE = {
 export const STORAGEKEY = {
   baseURL: 'baseURL',
 }
+
+export const JOBSTATUS = {
+  APPLIED: 'Applied',
+  NOTAPPLIED: 'Not Applied',
+  ASSESSMENT: 'Assessment',
+  VISANOTSUPPORTED: 'Visa not Supported',
+  REJECTED: 'Rejected',
+  CLOSED: 'Closed',
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 
 body {
-  width: 600px;
+  width: 540px;
   height: 500px;
   overflow: hidden;
 }

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -94,9 +94,16 @@ describe('API Success cases', () => {
   test('updateJob sends PUT request', async () => {
     fetch.mockResolvedValueOnce({ ok: true })
 
-    await updateJob('id')
+    let body = {
+      title: 'Updated Job Title',
+      company: 'Updated Company',
+    }
+
+    await updateJob('id', body)
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/id'), {
       method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
     })
   })
 })
@@ -131,6 +138,6 @@ describe('API failure cases', () => {
 
   test('updateJob throws error when fetch fails', async () => {
     fetch.mockResolvedValueOnce({ ok: false })
-    await expect(updateJob('id')).rejects.toThrow('Failed to update job')
+    await expect(updateJob('id', {})).rejects.toThrow('Failed to update job')
   })
 })


### PR DESCRIPTION
This PR implements the feature for updating saved job posting status.

 - Replaced the applied button on the job listing table with an edit button.
 - Updated api endpoints for getting job postings.
 - Updated update job service endpoint to work with different status strings instead of the "Applied" string only.
 - Replaced string values for llm model selection with an enum on the backend